### PR TITLE
fix: DeformableコンポーネントのインスペクターでDeformersリストに要素を追加・削除するボタン（+/-）が表示されない

### DIFF
--- a/Code/Editor/Mesh/DeformableEditorExtention.cs
+++ b/Code/Editor/Mesh/DeformableEditorExtention.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,39 +16,6 @@ namespace DeformEditor
 		{
 			deformerList?.Dispose();
 			deformerList = null;
-		}
-		
-		public override VisualElement CreateInspectorGUI() {
-			var root = base.CreateInspectorGUI() ?? new VisualElement();
-
-			root.Add (new IMGUIContainer(DrawIMGUI(DrawMainSettings)){style = {
-				marginBottom = 10
-			}});
-			
-			//root.Add (new IMGUIContainer(DrawIMGUI(DrawDeformersList)){style = {
-			//	marginBottom = 10
-			//}});
-			new ReorderableComponentElementList<Deform.Deformer>(root, serializedObject, serializedObject.FindProperty("deformerElements"));
-			root.Q<ListView>().Q<Toggle>().pickingMode = PickingMode.Ignore;
-			root.Q<ListView>().Q<Toggle>().Query<VisualElement>().ForEach(ve => ve.pickingMode = PickingMode.Ignore);
-
-			root.Add (new IMGUIContainer(DrawIMGUI(DrawUtilityToolbar)){style = {
-				marginBottom = 10
-			}});
-			
-			root.Add (new IMGUIContainer(DrawIMGUI(DrawDebugInfo)));
-			root.Add (new IMGUIContainer(DrawIMGUI(DrawHelpBoxes)));
-			
-			return root;
-		}
-		
-		Action DrawIMGUI(Action onGUIHandler){
-			return () => {
-			serializedObject.UpdateIfRequiredOrScript();
-			onGUIHandler();
-			if (serializedObject.ApplyModifiedProperties())
-				EditorApplication.QueuePlayerLoopUpdate();
-			};
 		}
 	}
 }


### PR DESCRIPTION
# Fix: DeformableコンポーネントのインスペクターでDeformersリストに要素を追加・削除するボタン（+/-）が表示されない

https://github.com/c-colloid/NDMFDeform/issues/9

## 概要

`DeformableEditorExtention.cs`のUIToolkit `ListView`実装では、Deformersリストの追加・削除ボタンが正しく表示されません。このPRでは`CreateInspectorGUI()`メソッドを削除し、正しくリスト操作ボタンを表示するIMGUI版の`OnInspectorGUI()`実装にフォールバックしてみました。間違った修正であればCloseしてください。

## 問題

- `CreateInspectorGUI()`メソッドがUIToolkitの`ListView`コンポーネントを使用
- ListViewでDeformerの追加・削除に必要な+/-ボタンが表示されない
- ユーザーがDeformableのDeformersリストにDeformerコンポーネントを追加できない

## 解決策

- `DeformableEditorExtention.cs`から`CreateInspectorGUI()`と`DrawIMGUI()`メソッドを削除
- UnityがIMGUIベースの`OnInspectorGUI()`メソッドを使用するようになる
- IMGUIの`ReorderableList`が追加・削除ボタンを正しく表示

## 変更内容

**変更ファイル**: `Code/Editor/Mesh/DeformableEditorExtention.cs`
- `CreateInspectorGUI()`メソッドを削除（21-43行目）
- `DrawIMGUI()`ヘルパーメソッドを削除（45-52行目）
- クリーンアップ用の`OnDestroy()`メソッドのみ保持

## テスト

Unity 2022.3.22f1でテスト済み:
1. GameObjectにDeformableコンポーネントを追加
2. 子GameObjectにDeformerコンポーネント（例: TwistDeformer）を追加
3. DeformableインスペクターのDeformersリストに+/-ボタンが表示されることを確認
4. ボタンを使用してDeformerの追加・削除が正常に動作することを確認

## 関連Issue

Unity 2022.3.22f1でDeformableインスペクターのDeformersリスト管理ボタンが表示されない問題に対応。
